### PR TITLE
add dataloader and pretraining script for mixed pretrain/sft 

### DIFF
--- a/litgpt/__main__.py
+++ b/litgpt/__main__.py
@@ -14,6 +14,7 @@ from litgpt.generate.full import main as generate_full_fn
 from litgpt.generate.sequentially import main as generate_sequentially_fn
 from litgpt.generate.tp import main as generate_tp_fn
 from litgpt.pretrain import setup as pretrain_fn
+from litgpt.pretrain_mixed import setup as pretrain_mixed_fn
 from litgpt.scripts.convert_hf_checkpoint import convert_hf_checkpoint as convert_hf_checkpoint_fn
 from litgpt.scripts.convert_lit_checkpoint import convert_lit_checkpoint as convert_lit_checkpoint_fn
 from litgpt.scripts.convert_pretrained_checkpoint import (
@@ -36,6 +37,7 @@ def main() -> None:
         "finetune_adapter": finetune_adapter_fn,
         "finetune_adapter_v2": finetune_adapter_v2_fn,
         "pretrain": pretrain_fn,
+        "pretrain_mixed": pretrain_mixed_fn,
         "generate": generate_base_fn,
         "generate_full": generate_full_fn,
         "generate_adapter": generate_adapter_fn,

--- a/litgpt/data/__init__.py
+++ b/litgpt/data/__init__.py
@@ -16,6 +16,7 @@ from litgpt.data.tinyllama import TinyLlama
 from litgpt.data.tinystories import TinyStories
 from litgpt.data.openwebtext import OpenWebText
 from litgpt.data.microllama import MicroLlama
+from litgpt.data.mixed_dataset import MixedDataset
 
 
 __all__ = [
@@ -35,6 +36,7 @@ __all__ = [
     "TextFiles",
     "TinyLlama",
     "TinyStories",
-    "MicroLlama"
+    "MicroLlama",
+    "MixedDataset",
     "get_sft_collate_fn",
 ]

--- a/litgpt/data/mixed_dataset.py
+++ b/litgpt/data/mixed_dataset.py
@@ -1,0 +1,574 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+from dataclasses import dataclass, field
+from torch.utils.data import DataLoader, IterableDataset
+from pathlib import Path
+import os
+import glob
+from torch.utils.data import BatchSampler
+
+from litdata.streaming import TokensLoader, StreamingDataLoader, StreamingDataset
+from litgpt.data import DataModule
+from litgpt.data.json_data import load_split
+from litgpt.data.text_files import optimize_data
+from litgpt.data.base import SFTDataset, get_sft_collate_fn
+from litgpt.tokenizer import Tokenizer
+from litgpt import PromptStyle
+
+### For CombinedLoader
+import contextlib
+from collections.abc import Iterable
+from typing import Any, Callable, Dict, Iterator, List, Literal, Optional, Tuple, Type, Union
+
+from torch.utils.data.dataloader import _BaseDataLoaderIter, _MultiProcessingDataLoaderIter
+from torch.utils.data import DataLoader
+from typing_extensions import Self, TypedDict, override
+
+from lightning.fabric.utilities.data import sized_len
+from lightning.fabric.utilities.types import _Stateful
+from lightning.pytorch.utilities._pytree import _map_and_unflatten, _tree_flatten, tree_unflatten
+
+@dataclass
+class MixedDataset(DataModule):
+    """
+    A dataset that blends together unstructured text (the usual pretraining data) and structured text (SFT data). Can have different proportions of each that evolve over time.
+    """
+
+    # A path to a directory containing both pretraining data (files in txt form) as well as SFT data (json files). Should contain two subdirectories "texts" and "sft".
+    data_path: str = "data/"
+    max_seq_length: int = field(init=False, repr=False, default=2048)
+    tokenizer: Optional[Tokenizer] = field(default=None, init=False, repr=False)
+    prompt_style: Union[str, PromptStyle] = "alpaca"
+    mask_prompt: bool = False
+    ignore_index: int = -100
+    seed: int = 42
+    num_workers: int = 4
+
+
+    def __post_init__(self):
+        self.lm_train_path = Path(str(self.data_path).rstrip("/") + "/texts/train_raw/")
+        self.lm_val_path = Path(str(self.data_path).rstrip("/") + "/texts/val_raw/")
+
+        self.sft_train_path = Path(str(self.data_path).rstrip("/") + "/sft/train/train.json")
+        self.sft_val_path = Path(str(self.data_path).rstrip("/") + "/sft/val/val.json")
+
+        # TODO: for now assume there's only one jsonl/json file in each sft dir. We should iterate over multiple though to make it easier to add datasets
+        self.sft_train_data = load_split(self.sft_train_path)
+        self.sft_val_data = load_split(self.sft_val_path)
+        #self.lm_train_data = load_split(self.lm_train_path)
+        #self.lm_val_data = load_split(self.lm_val_path)
+
+        self.out_path_train_lm = self.data_path + "/texts/train/"
+        self.out_path_val_lm = self.data_path + "/texts/val/" 
+
+    def setup(self):
+        self.sft_train_dataset = SFTDataset(
+            data=self.sft_train_data,
+            tokenizer=self.tokenizer,
+            prompt_style=self.prompt_style,
+            max_seq_length=self.max_seq_length_sft,
+            mask_prompt=self.mask_prompt,
+            ignore_index=self.ignore_index,
+        )
+        self.sft_test_dataset = SFTDataset(
+            data=self.sft_val_data,
+            tokenizer=self.tokenizer,
+            prompt_style=self.prompt_style,
+            max_seq_length=self.max_seq_length_sft,
+            mask_prompt=self.mask_prompt,
+            ignore_index=self.ignore_index,
+        )
+    
+    def connect(self, tokenizer: Optional[Tokenizer] = None, batch_size: int = 1, max_seq_length: int = -1) -> None:
+        self.tokenizer = tokenizer
+        self.batch_size = batch_size
+        self.max_seq_length_sft = max_seq_length
+        self.max_seq_length_lm = max_seq_length + 1
+
+    def prepare_data(self) -> None:
+        train_files = sorted(glob.glob(str(self.lm_train_path / "*.txt")))
+        assert len(train_files) > 0, f"No .txt files found in train data {train_files}"
+
+        if self.lm_val_path is not None:
+            self.lm_val_path = Path(self.lm_val_path)
+            val_files = sorted(glob.glob(str(self.lm_val_path / "*.txt")))
+            assert len(val_files) > 0, f"No .txt files found in validation data {val_files}"
+        # train/test split. let's use only shard 0 for test split, rest train
+        else:
+            assert len(train_files) > 1, f"Expected at least two .txt files in {train_files}"
+            val_files, *train_files = train_files
+            val_files = [val_files]
+
+        # It's ok to use almost all CPUs here because this runs in a single process
+        # TODO: left off here - encapsulate this part and call it in mixed dataset
+        num_workers = os.cpu_count() - 1
+
+        optimize_data(num_workers, str(self.out_path_train_lm), str(self.out_path_val_lm), self.tokenizer, train_files, val_files)
+
+    def train_dataloader(self) -> DataLoader:
+        from litgpt.data import DataModule, SFTDataset, get_sft_collate_fn
+        
+        self.lm_train_dataset = StreamingDataset(
+            input_dir=self.out_path_train_lm,
+            item_loader=TokensLoader(block_size=self.max_seq_length_lm),
+            shuffle=True,
+            drop_last=True,
+        )
+
+        lm_train_dataloader = StreamingDataLoader(
+            self.lm_train_dataset, batch_size=self.batch_size, pin_memory=True, drop_last=True
+        )
+        sft_train_dataloader = DataLoader(
+            self.sft_train_dataset,
+            batch_size=self.batch_size,
+            shuffle=True,
+            num_workers=self.num_workers,
+            collate_fn=get_sft_collate_fn(
+                max_seq_length=self.max_seq_length_sft, ignore_index=self.ignore_index
+            ),
+        )
+
+        return CombinedLoader({"lm": lm_train_dataloader, "sft": sft_train_dataloader}, "max_size_cycle")
+
+    # TODO - should we return two separate validation sets and report metrics on both separately -- probably
+    def val_dataloader(self) -> DataLoader:
+        from litgpt.data import DataModule, SFTDataset, get_sft_collate_fn
+        
+        self.lm_test_dataset = StreamingDataset(
+            input_dir=self.out_path_val_lm,
+            item_loader=TokensLoader(block_size=self.max_seq_length_lm),
+            shuffle=True,
+            drop_last=True,
+        )
+
+        lm_test_dataloader = StreamingDataLoader(
+            self.lm_test_dataset, batch_size=self.batch_size, pin_memory=True, drop_last=True
+        )
+        sft_test_dataloader = DataLoader(
+            self.sft_test_dataset,
+            batch_size=self.batch_size,
+            shuffle=True,
+            num_workers=self.num_workers,
+            collate_fn=get_sft_collate_fn(
+                max_seq_length=self.max_seq_length_sft, ignore_index=self.ignore_index
+            ),
+        )
+
+        return CombinedLoader({"lm": lm_test_dataloader, "sft": sft_test_dataloader}, "max_size_cycle")
+
+
+### This code was not present in the current version of lightning. Adding it here
+# Copyright The Lightning AI team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+_ITERATOR_RETURN = Tuple[Any, int, int]  # batch, batch_idx, dataloader_idx
+
+
+class _ModeIterator(Iterator[_ITERATOR_RETURN]):
+    def __init__(self, iterables: List[Iterable], limits: Optional[List[Union[int, float]]] = None) -> None:
+        if limits is not None and len(limits) != len(iterables):
+            raise ValueError(f"Mismatch in number of limits ({len(limits)}) and number of iterables ({len(iterables)})")
+        self.iterables = iterables
+        self.iterators: List[Iterator] = []
+        self._idx = 0  # what would be batch_idx
+        self.limits = limits
+
+    @override
+    def __next__(self) -> _ITERATOR_RETURN:
+        raise NotImplementedError
+
+    @override
+    def __iter__(self) -> Self:
+        self.iterators = [iter(iterable) for iterable in self.iterables]
+        self._idx = 0
+        return self
+
+    def __len__(self) -> int:
+        raise NotImplementedError
+
+    def reset(self) -> None:
+        self.iterators = []
+        self._idx = 0
+
+    def __getstate__(self) -> Dict[str, Any]:
+        state = self.__dict__.copy()
+
+        # workaround an inconvenient `NotImplementedError`:
+        # https://github.com/pytorch/pytorch/blob/v2.0.0/torch/utils/data/dataloader.py#L652-L658
+        state["iterators"] = [
+            None if isinstance(iterator, _BaseDataLoaderIter) else iterator_state
+            for iterator, iterator_state in zip(self.iterators, state["iterators"])
+        ]
+
+        return state
+
+
+class _MaxSizeCycle(_ModeIterator):
+    def __init__(self, iterables: List[Iterable], limits: Optional[List[Union[int, float]]] = None) -> None:
+        super().__init__(iterables, limits)
+        self._consumed: List[bool] = []
+
+    @override
+    def __next__(self) -> _ITERATOR_RETURN:
+        n = len(self.iterators)
+        out = [None] * n  # values per iterator
+        for i in range(n):
+            try:
+                out[i] = next(self.iterators[i])
+            except StopIteration:
+                self._consumed[i] = True
+                if all(self._consumed):
+                    raise
+                # reset the consumed dataloader
+                self.iterators[i] = iter(self.iterables[i])
+                out[i] = next(self.iterators[i])
+        index = self._idx
+        self._idx += 1
+        return out, index, 0
+
+    @override
+    def __iter__(self) -> Self:
+        super().__iter__()
+        self._consumed = [False] * len(self.iterables)
+        return self
+
+    @override
+    def __len__(self) -> int:
+        lengths = _get_iterables_lengths(self.iterables)
+        if self.limits is not None:
+            return max(min(length, limit) for length, limit in zip(lengths, self.limits))  # type: ignore[return-value]
+        return max(lengths)  # type: ignore[return-value]
+
+    @override
+    def reset(self) -> None:
+        super().reset()
+        self._consumed = []
+
+
+class _MinSize(_ModeIterator):
+    @override
+    def __next__(self) -> _ITERATOR_RETURN:
+        out = [next(it) for it in self.iterators]
+        index = self._idx
+        self._idx += 1
+        return out, index, 0
+
+    @override
+    def __len__(self) -> int:
+        lengths = _get_iterables_lengths(self.iterables)
+        return min(lengths + self.limits) if self.limits is not None else min(lengths)  # type: ignore[return-value]
+
+
+class _Sequential(_ModeIterator):
+    def __init__(self, iterables: List[Iterable], limits: Optional[List[Union[int, float]]] = None) -> None:
+        super().__init__(iterables, limits)
+        self._iterator_idx = 0  # what would be dataloader_idx
+
+    @override
+    def __next__(self) -> _ITERATOR_RETURN:
+        n = len(self.iterables)
+        if n == 0 or self._iterator_idx >= n:
+            raise StopIteration
+
+        # if limits are set, go to the correct iterator
+        if self.limits is not None:
+            while self.limits[self._iterator_idx] <= self._idx:
+                self._use_next_iterator()
+                if self._iterator_idx >= n:
+                    raise StopIteration
+
+        try:
+            out = next(self.iterators[0])
+        except StopIteration:
+            # try the next iterator
+            self._use_next_iterator()
+            return self.__next__()
+        index = self._idx
+        self._idx += 1
+        return out, index, self._iterator_idx
+
+    @override
+    def __iter__(self) -> Self:
+        self._iterator_idx = 0
+        self._idx = 0
+        self._load_current_iterator()
+        return self
+
+    @override
+    def __len__(self) -> int:
+        lengths = _get_iterables_lengths(self.iterables)
+        if self.limits is not None:
+            return sum(min(length, limit) for length, limit in zip(lengths, self.limits))  # type: ignore[misc]
+        return sum(lengths)  # type: ignore[arg-type]
+
+    @override
+    def reset(self) -> None:
+        super().reset()
+        self._iterator_idx = 0
+
+    def _load_current_iterator(self) -> None:
+        # Load a single DataLoader, prevents multiple sets of workers from starting unnecessarily
+        if self._iterator_idx < len(self.iterables):
+            self.iterators = [iter(self.iterables[self._iterator_idx])]
+        else:
+            # No more iterables to step through, return an empty list
+            self.iterators = []
+
+    def _use_next_iterator(self) -> None:
+        self._iterator_idx += 1
+        self._idx = 0
+        self._load_current_iterator()
+
+
+class _MaxSize(_ModeIterator):
+    @override
+    def __next__(self) -> _ITERATOR_RETURN:
+        n = len(self.iterators)
+        out = [None] * n
+        all_exhausted = True
+        for i in range(n):
+            with contextlib.suppress(StopIteration):
+                out[i] = next(self.iterators[i])
+                all_exhausted = False
+        if all_exhausted:
+            raise StopIteration
+        index = self._idx
+        self._idx += 1
+        return out, index, 0
+
+    @override
+    def __len__(self) -> int:
+        lengths = _get_iterables_lengths(self.iterables)
+        if self.limits is not None:
+            return max(min(length, limit) for length, limit in zip(lengths, self.limits))  # type: ignore[return-value]
+        return max(lengths)  # type: ignore[return-value]
+
+
+class _CombinationMode(TypedDict):
+    fn: Callable[[List[int]], int]
+    iterator: Type[_ModeIterator]
+
+
+_SUPPORTED_MODES = {
+    "min_size": _CombinationMode(fn=min, iterator=_MinSize),
+    "max_size_cycle": _CombinationMode(fn=max, iterator=_MaxSizeCycle),
+    "max_size": _CombinationMode(fn=max, iterator=_MaxSize),
+    "sequential": _CombinationMode(fn=sum, iterator=_Sequential),
+}
+_LITERAL_SUPPORTED_MODES = Literal["min_size", "max_size_cycle", "max_size", "sequential"]
+
+
+class CombinedLoader(DataLoader):
+    """Combines different iterables under specific sampling modes.
+
+    Args:
+        iterables: the iterable or collection of iterables to sample from.
+        mode: the mode to use. The following modes are supported:
+
+            * ``min_size``: stops after the shortest iterable (the one with the lowest number of items) is done.
+            * ``max_size_cycle``: stops after the longest iterable (the one with most items) is done, while cycling
+              through the rest of the iterables.
+            * ``max_size``: stops after the longest iterable (the one with most items) is done, while returning None
+              for the exhausted iterables.
+            * ``sequential``: completely consumes each iterable sequentially, and returns a triplet
+              ``(data, idx, iterable_idx)``
+
+    Examples:
+        >>> from torch.utils.data import DataLoader
+        >>> iterables = {'a': DataLoader(range(6), batch_size=4),
+        ...              'b': DataLoader(range(15), batch_size=5)}
+        >>> combined_loader = CombinedLoader(iterables, 'max_size_cycle')
+        >>> _ = iter(combined_loader)
+        >>> len(combined_loader)
+        3
+        >>> for batch, batch_idx, dataloader_idx in combined_loader:
+        ...     print(f"{batch}, {batch_idx=}, {dataloader_idx=}")
+        {'a': tensor([0, 1, 2, 3]), 'b': tensor([0, 1, 2, 3, 4])}, batch_idx=0, dataloader_idx=0
+        {'a': tensor([4, 5]), 'b': tensor([5, 6, 7, 8, 9])}, batch_idx=1, dataloader_idx=0
+        {'a': tensor([0, 1, 2, 3]), 'b': tensor([10, 11, 12, 13, 14])}, batch_idx=2, dataloader_idx=0
+
+        >>> combined_loader = CombinedLoader(iterables, 'max_size')
+        >>> _ = iter(combined_loader)
+        >>> len(combined_loader)
+        3
+        >>> for batch, batch_idx, dataloader_idx in combined_loader:
+        ...     print(f"{batch}, {batch_idx=}, {dataloader_idx=}")
+        {'a': tensor([0, 1, 2, 3]), 'b': tensor([0, 1, 2, 3, 4])}, batch_idx=0, dataloader_idx=0
+        {'a': tensor([4, 5]), 'b': tensor([5, 6, 7, 8, 9])}, batch_idx=1, dataloader_idx=0
+        {'a': None, 'b': tensor([10, 11, 12, 13, 14])}, batch_idx=2, dataloader_idx=0
+
+        >>> combined_loader = CombinedLoader(iterables, 'min_size')
+        >>> _ = iter(combined_loader)
+        >>> len(combined_loader)
+        2
+        >>> for batch, batch_idx, dataloader_idx in combined_loader:
+        ...     print(f"{batch}, {batch_idx=}, {dataloader_idx=}")
+        {'a': tensor([0, 1, 2, 3]), 'b': tensor([0, 1, 2, 3, 4])}, batch_idx=0, dataloader_idx=0
+        {'a': tensor([4, 5]), 'b': tensor([5, 6, 7, 8, 9])}, batch_idx=1, dataloader_idx=0
+
+        >>> combined_loader = CombinedLoader(iterables, 'sequential')
+        >>> _ = iter(combined_loader)
+        >>> len(combined_loader)
+        5
+        >>> for batch, batch_idx, dataloader_idx in combined_loader:
+        ...     print(f"{batch}, {batch_idx=}, {dataloader_idx=}")
+        tensor([0, 1, 2, 3]), batch_idx=0, dataloader_idx=0
+        tensor([4, 5]), batch_idx=1, dataloader_idx=0
+        tensor([0, 1, 2, 3, 4]), batch_idx=0, dataloader_idx=1
+        tensor([5, 6, 7, 8, 9]), batch_idx=1, dataloader_idx=1
+        tensor([10, 11, 12, 13, 14]), batch_idx=2, dataloader_idx=1
+
+    """
+
+    def __init__(self, iterables: Any, mode: _LITERAL_SUPPORTED_MODES = "min_size") -> None:
+        if mode not in _SUPPORTED_MODES:
+            raise ValueError(f"Unsupported mode {mode!r}, please select one of: {list(_SUPPORTED_MODES)}.")
+        self._iterables = iterables
+        self._flattened, self._spec = _tree_flatten(iterables)
+        self._mode = mode
+        self._iterator: Optional[_ModeIterator] = None
+        self._limits: Optional[List[Union[int, float]]] = None
+        self.multiprocessing_context = None # is this a good default?
+
+    @property
+    def iterables(self) -> Any:
+        """Return the original collection of iterables."""
+        return self._iterables
+
+    @property
+    def sampler(self) -> Any:
+        """Return a collections of samplers extracted from iterables."""
+        return UnifiedBatchSampler(_map_and_unflatten(lambda x: getattr(x, "sampler", None), self.flattened, self._spec))
+
+    @property
+    def batch_sampler(self) -> Any:
+        """Return a collections of batch samplers extracted from iterables."""
+        return UnifiedBatchSampler(_map_and_unflatten(lambda x: getattr(x, "batch_sampler", None), self.flattened, self._spec))
+
+    @property
+    def flattened(self) -> List[Any]:
+        """Return the flat list of iterables."""
+        return self._flattened
+
+    @flattened.setter
+    def flattened(self, flattened: List[Any]) -> None:
+        """Setter to conveniently update the list of iterables."""
+        if len(flattened) != len(self._flattened):
+            raise ValueError(
+                f"Mismatch in flattened length ({len(flattened)}) and existing length ({len(self._flattened)})"
+            )
+        # update the iterable collection
+        self._iterables = tree_unflatten(flattened, self._spec)
+        self._flattened = flattened
+
+    @property
+    def limits(self) -> Optional[List[Union[int, float]]]:
+        """Optional limits per iterator."""
+        return self._limits
+
+    @limits.setter
+    def limits(self, limits: Optional[Union[int, float, List[Union[int, float]]]]) -> None:
+        if isinstance(limits, (int, float)):
+            limits = [limits] * len(self.flattened)
+        elif isinstance(limits, list) and len(limits) != len(self.flattened):
+            raise ValueError(
+                f"Mismatch in number of limits ({len(limits)}) and number of iterables ({len(self.flattened)})"
+            )
+        self._limits = limits
+
+    def __next__(self) -> _ITERATOR_RETURN:
+        assert self._iterator is not None
+        out = next(self._iterator)
+        if isinstance(self._iterator, _Sequential):
+            return out
+        out, batch_idx, dataloader_idx = out
+        return tree_unflatten(out, self._spec), batch_idx, dataloader_idx
+
+    @override
+    def __iter__(self) -> Self:
+        cls = _SUPPORTED_MODES[self._mode]["iterator"]
+        iterator = cls(self.flattened, self._limits)
+        iter(iterator)
+        self._iterator = iterator
+        return self
+
+    def __len__(self) -> int:
+        """Compute the number of batches."""
+        if self._iterator is None:
+            raise RuntimeError("Please call `iter(combined_loader)` first.")
+        return len(self._iterator)
+
+    def reset(self) -> None:
+        """Reset the state and shutdown any workers."""
+        if self._iterator is not None:
+            self._iterator.reset()
+            self._iterator = None
+        for iterable in self.flattened:
+            _shutdown_workers_and_reset_iterator(iterable)
+
+    def _dataset_length(self) -> int:
+        """Compute the total length of the datasets according to the current mode."""
+        datasets = [getattr(dl, "dataset", None) for dl in self.flattened]
+        lengths = [length for ds in datasets if (length := sized_len(ds)) is not None]
+        if not lengths:
+            raise NotImplementedError("All datasets are iterable-style datasets.")
+        fn = _SUPPORTED_MODES[self._mode]["fn"]
+        return fn(lengths)
+
+    def _state_dicts(self) -> List[Dict[str, Any]]:
+        """Returns the list of state dicts for iterables in `self.flattened` that are stateful."""
+        return [loader.state_dict() for loader in self.flattened if isinstance(loader, _Stateful)]
+
+    def _load_state_dicts(self, states: List[Dict[str, Any]]) -> None:
+        """Loads the state dicts for iterables in `self.flattened` that are stateful."""
+        if not states:
+            return
+        stateful_loaders = [loader for loader in self.flattened if isinstance(loader, _Stateful)]
+        if len(stateful_loaders) != len(states):
+            raise RuntimeError(
+                f"The CombinedLoader has {len(stateful_loaders)} stateful loaders, but found {len(states)} states"
+                " in the checkpoint. Please make sure you define the same dataloaders that were used when saving"
+                " the checkpoint."
+            )
+        for loader, state_dict in zip(stateful_loaders, states):
+            loader.load_state_dict(state_dict)
+
+
+def _shutdown_workers_and_reset_iterator(dataloader: object) -> None:
+    if hasattr(dataloader, "_iterator"):
+        if isinstance(dataloader._iterator, _MultiProcessingDataLoaderIter):
+            dataloader._iterator._shutdown_workers()
+        dataloader._iterator = None
+
+
+def _get_iterables_lengths(iterables: List[Iterable]) -> List[Union[int, float]]:
+    return [(float("inf") if (length := sized_len(iterable)) is None else length) for iterable in iterables]
+
+class UnifiedBatchSampler(BatchSampler):
+    def __init__(self, batch_samplers):
+        self.batch_samplers = batch_samplers
+        self.samplers_iter = {key: iter(sampler) for key, sampler in batch_samplers.items()}
+    def __iter__(self):
+        active_samplers = list(self.samplers_iter.keys())
+        while active_samplers:
+            for key in list(active_samplers):  # List to avoid modification during iteration
+                try:
+                    batch = next(self.samplers_iter[key])
+                    yield batch
+                except StopIteration:
+                    active_samplers.remove(key)
+                    del self.samplers_iter[key]
+    def __len__(self):
+        # This might need to be adjusted based on how you decide to combine the batches
+        return sum(len(sampler) for sampler in self.batch_samplers.values())

--- a/litgpt/pretrain_mixed.py
+++ b/litgpt/pretrain_mixed.py
@@ -1,0 +1,544 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
+import math
+import pprint
+import time
+from datetime import timedelta
+from functools import partial
+from pathlib import Path
+from typing import Dict, Optional, Tuple, Union
+
+import lightning as L
+import torch
+import torch.nn as nn
+from lightning.fabric.strategies import FSDPStrategy
+from lightning.fabric.utilities.throughput import measure_flops, ThroughputMonitor
+
+from litgpt import Tokenizer
+from litgpt.args import EvalArgs, TrainArgs
+from litgpt.config import name_to_config
+from litgpt.data import DataModule, MicroLlama, TinyLlama
+from litgpt.model import Block, CausalSelfAttention, Config, GPT, LLaMAMLP
+from litgpt.utils import (
+    capture_hparams,
+    choose_logger,
+    chunked_cross_entropy,
+    copy_config_files,
+    CycleIterator,
+    extend_checkpoint_dir,
+    get_default_supported_precision,
+    init_out_dir,
+    instantiate_torch_optimizer,
+    num_parameters,
+    parse_devices,
+    reset_parameters,
+    save_config,
+    save_hyperparameters,
+)
+from torch.utils.data import DataLoader
+from torchmetrics.aggregation import RunningMean
+from typing_extensions import Literal
+
+
+def setup(
+    model_name: str,
+    model_config: Optional[Config] = None,
+    out_dir: Path = Path("out/pretrain"),
+    precision: Literal["bf16-true", "bf16-mixed", "32-true", None] = None,
+    initial_checkpoint_dir: Optional[Path] = None,
+    resume: Union[bool, Path] = False,
+    data: Optional[DataModule] = None,
+    train: TrainArgs = TrainArgs(
+        save_interval=1000,
+        log_interval=1,
+        global_batch_size=512,
+        micro_batch_size=4,
+        max_tokens=int(3e12),  # 3 trillion
+        max_norm=1.0,
+        min_lr=4e-5,
+        lr_warmup_steps=2000,
+        tie_embeddings=False,
+    ),
+    eval: EvalArgs = EvalArgs(interval=1000, max_iters=100),
+    optimizer: Union[str, Dict] = "AdamW",
+    devices: Union[int, str] = "auto",
+    tokenizer_dir: Optional[Path] = None,
+    logger_name: Literal["wandb", "tensorboard", "csv"] = "tensorboard",
+    seed: int = 42,
+):
+    """Pretrain a model.
+
+    Arguments:
+        model_name: The name of the model to pretrain. Choose from names in ``litgpt.config``. Use "list" to list the supported models.
+        model_config: A ``litgpt.Config`` object to define the model architecture. Mutually exclusive with
+            ``model_config``. Overrides the `model_name` if specified.
+        out_dir: Directory in which to save checkpoints and logs. If running in a Lightning Studio Job, look for it in
+            /teamspace/jobs/<job-name>/share.
+        precision: The precision to use for finetuning. Determines a compatible precision setting by default.
+        initial_checkpoint_dir: Optional path to a checkpoint directory to initialize the model from.
+            Useful for continued pretraining. Mutually exclusive with ``resume``.
+        resume: Path to a checkpoint directory to resume from in case training was interrupted, or ``True`` to resume
+            from the latest checkpoint in ``out_dir``.
+        data: Data-related arguments. If not provided, the default is ``litgpt.data.TinyLlama``.
+        train: Training-related arguments. See ``litgpt.args.TrainArgs`` for details.
+        eval: Evaluation-related arguments. See ``litgpt.args.EvalArgs`` for details.
+        optimizer: An optimizer name (such as "AdamW") or config.
+
+        devices: How many devices/GPUs to use. Uses all GPUs by default.
+        tokenizer_dir: Optional path to the tokenizer dir that was used for preprocessing the dataset. Only some data
+            module require this.
+        logger_name: The name of the logger to send metrics to.
+        seed: The random seed to use for reproducibility.
+    """
+    if model_name == "list":
+        available_models = "\n".join(sorted(name_to_config))
+        print(f"Available values:\n{available_models}")
+        quit()
+
+    if initial_checkpoint_dir is not None:
+        initial_checkpoint_dir = extend_checkpoint_dir(initial_checkpoint_dir)
+
+    if tokenizer_dir is not None:
+        tokenizer_dir = extend_checkpoint_dir(tokenizer_dir)
+
+    if model_config is None:
+        # Support both model_name options: meta-llama/Meta-Llama-3-8B & Meta-Llama-3-8B
+        try:
+            model_config = Config.from_name(model_name)
+        except ValueError:
+            print(f"Model name {model_name} is not supported.\n")
+            available_models = "\n".join(sorted(name_to_config))
+            print(f"Available values:\n{available_models}")
+            quit()
+
+    hparams = capture_hparams()
+    data = TinyLlama() if data is None else data
+
+    config = Config.from_name(model_name) if model_config is None else model_config
+    precision = precision or get_default_supported_precision(training=True)
+    devices = parse_devices(devices)
+    out_dir = init_out_dir(out_dir)
+    # in case the dataset requires the Tokenizer
+    tokenizer = Tokenizer(tokenizer_dir) if tokenizer_dir is not None else None
+
+    logger = choose_logger(
+        logger_name, out_dir, name=f"pretrain-{config.name}", resume=resume, log_interval=train.log_interval
+    )
+
+    if devices > 1:
+        strategy = FSDPStrategy(auto_wrap_policy={Block}, state_dict_type="full", sharding_strategy="HYBRID_SHARD")
+    else:
+        strategy = "auto"
+    fabric = L.Fabric(devices=devices, strategy=strategy, precision=precision, loggers=[logger])
+    fabric.launch()
+
+    fabric.print(pprint.pformat(hparams))
+    if logger_name in ("tensorboard", "wandb"):
+        fabric.logger.log_hyperparams(hparams)
+
+    main(
+        fabric,
+        devices,
+        seed,
+        initial_checkpoint_dir,
+        resume,
+        config,
+        data,
+        out_dir,
+        tokenizer_dir,
+        tokenizer,
+        train,
+        eval,
+        optimizer,
+    )
+
+
+def main(
+    fabric: L.Fabric,
+    devices: int,
+    seed: int,
+    initial_checkpoint_dir: Optional[Path],
+    resume: Union[bool, Path],
+    config: Config,
+    data: DataModule,
+    out_dir: Path,
+    tokenizer_dir: Optional[Path],
+    tokenizer: Optional[Tokenizer],
+    train: TrainArgs,
+    eval: EvalArgs,
+    optimizer: Union[str, Dict],
+) -> None:
+    validate_args(train, eval, initial_checkpoint_dir, resume)
+
+    if fabric.global_rank == 0:
+        out_dir.mkdir(parents=True, exist_ok=True)
+
+    fabric.seed_everything(seed)  # same seed for every process to init model (FSDP)
+
+    t0 = time.perf_counter()
+    with fabric.init_module(empty_init=True):
+        model = GPT(config)
+
+    initialize_weights(fabric, model, n_layer=config.n_layer, n_embd=config.n_embd)
+
+    if train.tie_embeddings:
+        model.transformer.wte.weight = model.lm_head.weight
+    if train.max_seq_length:
+        model.max_seq_length = train.max_seq_length
+
+    fabric.print(f"Time to instantiate model: {time.perf_counter() - t0:.02f} seconds.")
+    fabric.print(f"Total parameters: {num_parameters(model):,}")
+
+    model = torch.compile(model)
+    model = fabric.setup(model)
+
+    extra_kwargs = {"fused": fabric.device.type == "cuda"}
+    optimizer = instantiate_torch_optimizer(optimizer, model.parameters(), **extra_kwargs)
+    optimizer = fabric.setup_optimizers(optimizer)
+
+    train_dataloader, val_dataloader = get_dataloaders(fabric, data, tokenizer, train, model.max_seq_length)
+    train_dataloader, val_dataloader = fabric.setup_dataloaders(train_dataloader, val_dataloader)
+
+    if initial_checkpoint_dir:
+        fabric.load_raw(initial_checkpoint_dir / "lit_model.pth", model)
+
+    state = {
+        "model": model,
+        "optimizer": optimizer,
+        #"train_dataloader": train_dataloader,
+        "iter_num": 0,
+        "step_count": 0,
+    }
+
+    if resume is True:
+        resume = max(out_dir.rglob("step-*/*.pth"), key=(lambda p: int(p.parent.name.split("-")[1])))
+    if resume:
+        fabric.print(f"Resuming training from {resume}")
+        fabric.load(resume, state)
+
+    train_time = time.perf_counter()
+    fit(fabric, devices, state, train_dataloader, val_dataloader, out_dir, tokenizer_dir, train, eval)
+
+    # Save final checkpoint
+    save_checkpoint(fabric, state, tokenizer_dir, out_dir / "final" / "lit_model.pth")
+
+    fabric.print(f"Training time: {(time.perf_counter()-train_time):.2f}s")
+    if fabric.device.type == "cuda":
+        fabric.print(f"Memory used: {torch.cuda.max_memory_allocated() / 1e9:.02f} GB")
+
+
+def fit(
+    fabric: L.Fabric,
+    devices: int,
+    state: dict,
+    train_dataloader: DataLoader,
+    val_dataloader: DataLoader,
+    out_dir: Path,
+    tokenizer_dir: Optional[Path],
+    train: TrainArgs,
+    eval: EvalArgs,
+) -> None:
+    model = state["model"]
+    optimizer = state["optimizer"]
+
+    if eval.initial_validation:
+        val_loss, val_loss_lm, val_loss_sft = validate(fabric, model, val_dataloader, max_iters=eval.max_iters)
+        val_loss = f"{val_loss:.3f}"
+        val_loss_lm = f"{val_loss_lm:.3f}"
+        val_loss_sft = f"{val_loss_sft:.3f}"
+    else:
+        validate(fabric, model, val_dataloader, max_iters=2)   # sanity check
+        val_loss = "n/a"
+
+    throughput = ThroughputMonitor(fabric, window_size=5)
+
+    with torch.device("meta"):
+        meta_model = GPT(model.config)
+        x = torch.randint(0, 1, (train.micro_batch_size, meta_model.max_seq_length))
+        model_fwd = lambda: meta_model(x)
+        model_loss = lambda y: chunked_cross_entropy(y, x, chunk_size=0)
+        measured_flops = measure_flops(meta_model, model_fwd, model_loss)
+        fabric.print(f"Measured TFLOPs: {measured_flops * fabric.world_size / 1e12:.2f}")
+        del meta_model, x
+
+    max_tokens_per_device = train.max_tokens // fabric.world_size
+    tokens_per_iter = train.micro_batch_size * model.max_seq_length
+    max_iters = max_tokens_per_device // tokens_per_iter
+    log_iter_interval = train.log_interval * train.gradient_accumulation_iters(devices)
+    initial_iter = state["iter_num"]
+    train_iterator = CycleIterator(train_dataloader)
+
+    running_loss_total = RunningMean(window=train.gradient_accumulation_iters(devices), sync_on_compute=False).to(
+        fabric.device
+    )
+    lm_loss_total = RunningMean(window=train.gradient_accumulation_iters(devices), sync_on_compute=False).to(fabric.device)
+    sft_loss_total = RunningMean(window=train.gradient_accumulation_iters(devices), sync_on_compute=False).to(fabric.device)
+
+    fabric.barrier()
+    total_t0 = time.perf_counter()
+
+    warmup_iters = train.warmup_iters(devices, max_iters, train_dataloader)
+
+    for train_data in train_iterator:
+        if state["iter_num"] >= max_iters:
+            break
+
+        # determine and set the learning rate for this iteration
+        lr = get_lr(optimizer.defaults["lr"], state["iter_num"], warmup_iters, max_iters, train.min_lr)
+        for param_group in optimizer.param_groups:
+            param_group["lr"] = lr
+
+        state["iter_num"] += 1
+        iter_t0 = time.perf_counter()
+
+        if isinstance(train_data, tuple): # TODO: this iterator is structured weirdly, maybe reconsider. 
+            # structure: ({"sft": sft_data, "lm": lm_data}, batch_idx, dataloader_idx)
+            paired_data = train_data[0]
+            sft_data = paired_data.get("sft", None)
+            lm_data = paired_data.get("lm", None)
+            batch_idx = train_data[1]
+            dataloader_idx = train_data[2]
+
+        # Process LM data
+        #breakpoint()
+        is_accumulating = state["iter_num"] % train.gradient_accumulation_iters(devices) != 0
+
+        if lm_data is not None:
+            input_ids = lm_data[:, 0 : model.max_seq_length].contiguous().long()
+            targets = lm_data[:, 1 : (model.max_seq_length + 1)].contiguous().long()
+            logits = model(input_ids)
+            loss = chunked_cross_entropy(logits, targets) * 0.9              
+
+            running_loss_total.update(loss.detach())
+            lm_loss_total.update(loss.detach())
+
+        # rocess SFT data
+        if sft_data is not None:
+            input_ids, targets = sft_data["input_ids"], sft_data["labels"]
+            logits = model(input_ids)
+            sft_loss = chunked_cross_entropy(logits[..., :-1, :], targets[..., 1:], chunk_size=0)
+            loss += sft_loss * 0.1
+
+            running_loss_total.update(sft_loss.detach())
+            sft_loss_total.update(sft_loss.detach())
+        
+        # backprop
+        with fabric.no_backward_sync(model, enabled=is_accumulating):
+            fabric.backward(loss / train.gradient_accumulation_iters(devices))
+
+        if not is_accumulating:
+            fabric.clip_gradients(model, optimizer, max_norm=train.max_norm)
+            optimizer.step()
+            optimizer.zero_grad()
+            state["step_count"] += 1
+
+        if state["iter_num"] % log_iter_interval == 0:
+            loss = running_loss_total.compute().item()  # expensive device-to-host synchronization
+            loss_lm = lm_loss_total.compute().item()
+            loss_sft = sft_loss_total.compute().item()
+            t1 = time.perf_counter()
+            throughput.update(
+                time=(t1 - total_t0),
+                flops=(measured_flops * log_iter_interval),
+                batches=state["iter_num"],
+                samples=(state["iter_num"] * train.micro_batch_size),
+                lengths=(state["iter_num"] * train.micro_batch_size * model.max_seq_length),
+            )
+            metrics = {
+                "loss": loss,
+                "loss_lm": loss_lm,
+                "loss_sft": loss_sft,
+                "iter": state["iter_num"],
+                "step": state["step_count"],
+                "epoch": train_iterator.epoch,
+                "iter_time": t1 - iter_t0,
+                "remaining_time": (
+                    (t1 - total_t0) / (state["iter_num"] - initial_iter) * (max_iters - state["iter_num"])
+                ),
+                "tokens": state["iter_num"] * train.micro_batch_size * model.max_seq_length,
+                "total_tokens": (state["iter_num"] * train.micro_batch_size * model.max_seq_length * fabric.world_size),
+                "learning_rate": lr,
+            }
+            if isinstance(val_loss, float):
+                val_loss = f"{val_loss:.3f}"
+            fabric.print(
+                f"Epoch {metrics['epoch']+1} | iter {metrics['iter']} step {metrics['step']} |"
+                f" loss train: {metrics['loss']:.3f},"
+                f" loss train (lm): {metrics['loss_lm']}",
+                f" loss train (sft): {metrics['loss_sft']}",
+                f" val: {val_loss} |"
+                f" iter time: {metrics['iter_time'] * 1000:.2f} ms"
+                f"{' (step)' if not is_accumulating else ''}"
+                f" remaining time: {timedelta(seconds=int(metrics['remaining_time']))!s}"
+            )
+
+            throughput_metrics = throughput.compute()
+            metrics.update(throughput_metrics)
+            fabric.log_dict(metrics, step=state["iter_num"] - 1)
+
+        if val_dataloader is not None and not is_accumulating and state["step_count"] % eval.interval == 0:
+            t0 = time.perf_counter()
+            val_loss, val_loss_lm, val_loss_sft = validate(fabric, model, val_dataloader, max_iters=eval.max_iters)
+            val_loss = val_loss.item()
+            val_loss_lm = val_loss_lm.item()
+            val_loss_sft = val_loss_sft.item()
+            td = time.perf_counter() - t0
+
+            fabric.print(f"iter {state['iter_num']}: val loss {val_loss:.4f}, (lm subset): {val_loss_lm:.4f}, (sft subset): {val_loss_sft:.4f}, val time: {td * 1000:.2f} ms")
+            metrics = {"val_loss": val_loss, "val_loss_lm": val_loss_lm, "val_loss_sft": val_loss_sft, "val_ppl": math.exp(val_loss)}
+            fabric.log_dict(metrics, step=state["iter_num"] - 1)
+            fabric.barrier()
+
+        if train.save_interval is not None and not is_accumulating and state["step_count"] % train.save_interval == 0:
+            save_checkpoint(fabric, state, tokenizer_dir, out_dir / f"step-{state['step_count']:08d}" / "lit_model.pth")
+
+    # Final validation
+    if eval.final_validation:
+        val_loss, val_loss_lm, val_loss_sft = validate(fabric, model, val_dataloader, max_iters=eval.max_iters)
+        metrics = {"val_loss": val_loss, "val_loss_lm": val_loss_lm, "val_loss_sft": val_loss_sft, "val_ppl": math.exp(val_loss)}
+        fabric.log_dict(metrics, step=state["iter_num"])
+        fabric.print(f"Final evaluation | val loss: {val_loss.item():.3f} (lm): {val_loss_lm.item():.3f} (sft): {val_loss_sft.item():.3f} | val ppl: {math.exp(val_loss):.3f}")
+
+
+@torch.no_grad()
+def validate(fabric: L.Fabric, model: nn.Module, val_dataloader: DataLoader, max_iters: int) -> torch.Tensor:
+    fabric.barrier()
+    fabric.print("Validating ...")
+    model.eval()
+
+    losses = []
+    losses_lm = []
+    losses_sft = []
+    for k, batch in enumerate(val_dataloader):
+        if k >= max_iters:
+            break
+        
+        #breakpoint() # why is the train dataloader different from the val dataloader what is this lol
+
+        if isinstance(batch, tuple): # TODO: this iterator is structured weirdly, maybe reconsider. 
+            # structure: ({"sft": sft_data, "lm": lm_data}, batch_idx, dataloader_idx)
+            paired_data = batch[0]
+            sft_data = paired_data.get("sft", None)
+            lm_data = paired_data.get("lm", None)
+            batch_idx = batch[1]
+            dataloader_idx = batch[2]
+
+        # Process LM data
+        if lm_data is not None:
+            input_ids = lm_data[:, 0 : model.max_seq_length].contiguous().long()
+            targets = lm_data[:, 1 : (model.max_seq_length + 1)].contiguous().long()
+            logits = model(input_ids)
+            loss = chunked_cross_entropy(logits, targets)               
+
+            losses.append(loss)
+            losses_lm.append(loss)
+
+        # Process SFT data
+        if sft_data is not None:
+            input_ids, targets = sft_data["input_ids"], sft_data["labels"]
+            logits = model(input_ids)
+            sft_loss = chunked_cross_entropy(logits[..., :-1, :], targets[..., 1:], chunk_size=0)
+            # issue is that this seq len is too long. Probably due to mismatch between sft length and lm dataset length
+
+            losses.append(sft_loss)
+            losses_sft.append(sft_loss)
+            
+        # if isinstance(batch, tuple): # I messed up and included extra metadata, I don't think this should break other stuff?
+        #     batch_idx = batch[1]
+        #     dataloader_idx = batch[2]
+        #     batch = batch[0] # remove extra metadata
+            
+
+        # input_ids = batch[:, 0 : model.max_seq_length].contiguous().long()
+        # targets = batch[:, 1 : (model.max_seq_length + 1)].contiguous().long()
+        # logits = model(input_ids)
+        # loss = chunked_cross_entropy(logits, targets)
+        # losses.append(loss)
+
+    val_loss = torch.stack(losses).mean()
+    val_loss_lm = torch.stack(losses_lm).mean()
+    val_loss_sft = torch.stack(losses_sft).mean()
+    model.train()
+    fabric.barrier()
+    return val_loss, val_loss_lm, val_loss_sft
+
+
+def get_dataloaders(
+    fabric: L.Fabric, data: DataModule, tokenizer: Tokenizer, train: TrainArgs, block_size: int
+) -> Tuple[DataLoader, DataLoader]:
+    data.connect(tokenizer=tokenizer, batch_size=train.micro_batch_size, max_seq_length=block_size)
+    with fabric.rank_zero_first():
+        data.prepare_data()
+    data.setup()
+    train_dataloader = data.train_dataloader()
+    val_dataloader = data.val_dataloader()
+    return train_dataloader, val_dataloader
+
+
+# learning rate decay scheduler (cosine with linear warmup)
+def get_lr(learning_rate: float, it: int, warmup_iters: int, max_iters: int, min_lr: float) -> float:
+    # 1) linear warmup for warmup_iters steps
+    if it < warmup_iters:
+        return learning_rate * it / warmup_iters
+    # 2) if it > max_iters, return min learning rate
+    if it > max_iters:
+        return min_lr
+    # 3) in between, use cosine decay down to min learning rate
+    decay_ratio = (it - warmup_iters) / (max_iters - warmup_iters)
+    assert 0 <= decay_ratio <= 1
+    coeff = 0.5 * (1.0 + math.cos(math.pi * decay_ratio))  # coeff ranges 0..1
+    return min_lr + coeff * (learning_rate - min_lr)
+
+
+def initialize_weights(fabric: L.Fabric, model: GPT, n_layer: int, n_embd: int) -> None:
+    """GPT-NeoX weight initialization (https://arxiv.org/abs/2204.06745)."""
+    # Adapted from https://github.com/jzhang38/TinyLlama
+
+    def init_weights(module, std):
+        nn.init.normal_(module.weight, mean=0.0, std=std)
+        if getattr(module, "bias", None) is not None:
+            nn.init.zeros_(module.bias)
+
+    for mod in model.modules():
+        if isinstance(mod, (nn.Embedding, nn.Linear)):
+            mod.reset_parameters = partial(init_weights, mod, std=math.sqrt(2.0 / 5 / n_embd))
+
+    # need a separate loop because `mod.proj` below is a `nn.Linear` too
+    for mod in model.modules():
+        if isinstance(mod, (LLaMAMLP, CausalSelfAttention)):
+            mod.proj.reset_parameters = partial(init_weights, mod.proj, std=(1 / math.sqrt(n_embd) / n_layer))
+
+    if not isinstance(fabric.strategy, FSDPStrategy):
+        reset_parameters(model)
+
+
+def save_checkpoint(fabric, state, tokenizer_dir, checkpoint_file):
+    breakpoint()
+    model = state["model"]
+    checkpoint_file.parent.mkdir(parents=True, exist_ok=True)
+    fabric.print(f"Saving checkpoint to {str(checkpoint_file)!r}")
+    fabric.save(checkpoint_file, state)
+    if fabric.global_rank == 0:
+        save_hyperparameters(setup, checkpoint_file.parent)
+        if tokenizer_dir is not None:
+            copy_config_files(tokenizer_dir, checkpoint_file.parent)
+        save_config(model.config, checkpoint_file.parent)
+
+
+def validate_args(train: TrainArgs, eval: EvalArgs, initial_checkpoint_dir, resume) -> None:
+    issues = []
+    unsupported = [(train, ["max_steps", "epochs"]), (eval, ["max_new_tokens"])]
+    for args, names in unsupported:
+        for name in names:
+            if getattr(args, name) is not None:
+                issues.append(f"{__file__} doesn't support the {name!r} argument. This is set in {args}")
+    required = [(train, ["max_tokens", "max_norm"])]
+    for args, names in required:
+        for name in names:
+            if getattr(args, name) is None:
+                issues.append(f"{__file__} requires the {name!r} argument. This is set in {args}")
+    if initial_checkpoint_dir and resume:
+        issues.append("Can't provide both `--resume` and `--initial_checkpoint_dir`. Choose one.")
+    if issues:
+        raise ValueError("\n".join(issues))

--- a/litgpt/pretrain_mixed.py
+++ b/litgpt/pretrain_mixed.py
@@ -301,7 +301,6 @@ def fit(
             dataloader_idx = train_data[2]
 
         # Process LM data
-        #breakpoint()
         is_accumulating = state["iter_num"] % train.gradient_accumulation_iters(devices) != 0
 
         if lm_data is not None:
@@ -414,8 +413,6 @@ def validate(fabric: L.Fabric, model: nn.Module, val_dataloader: DataLoader, max
         if k >= max_iters:
             break
         
-        #breakpoint() # why is the train dataloader different from the val dataloader what is this lol
-
         if isinstance(batch, tuple): # TODO: this iterator is structured weirdly, maybe reconsider. 
             # structure: ({"sft": sft_data, "lm": lm_data}, batch_idx, dataloader_idx)
             paired_data = batch[0]
@@ -444,17 +441,6 @@ def validate(fabric: L.Fabric, model: nn.Module, val_dataloader: DataLoader, max
             losses.append(sft_loss)
             losses_sft.append(sft_loss)
             
-        # if isinstance(batch, tuple): # I messed up and included extra metadata, I don't think this should break other stuff?
-        #     batch_idx = batch[1]
-        #     dataloader_idx = batch[2]
-        #     batch = batch[0] # remove extra metadata
-            
-
-        # input_ids = batch[:, 0 : model.max_seq_length].contiguous().long()
-        # targets = batch[:, 1 : (model.max_seq_length + 1)].contiguous().long()
-        # logits = model(input_ids)
-        # loss = chunked_cross_entropy(logits, targets)
-        # losses.append(loss)
 
     val_loss = torch.stack(losses).mean()
     val_loss_lm = torch.stack(losses_lm).mean()
@@ -514,7 +500,6 @@ def initialize_weights(fabric: L.Fabric, model: GPT, n_layer: int, n_embd: int) 
 
 
 def save_checkpoint(fabric, state, tokenizer_dir, checkpoint_file):
-    breakpoint()
     model = state["model"]
     checkpoint_file.parent.mkdir(parents=True, exist_ok=True)
     fabric.print(f"Saving checkpoint to {str(checkpoint_file)!r}")


### PR DESCRIPTION
This updates litgpt with a mixed dataset that consists of pretraining text (formatted as txt files) as well as a new pretraining script which works with the new dataset type. Currently, each batch now consists of <batch_size> sft samples as well as <batch size> txt samples, like this (this will be changed in the future, but for now it's a 1:1 ratio):
```
{"lm": <txt data> , "sft": <sft data>, ...}
```
The loss from both is currently just combined in a 90:10 ratio for the final loss.

**To test: **
You can now call litgpt with pretrain_mixed. The input files should be structured like this:
```
.
└── mixed_data_dir/
    ├── sft/
    │   ├── train/
    │   │   └── train.json
    │   └── val/
    │       └── val.json
    └── texts/
        ├── train_raw/
        │   └── train.txt
        └── val_raw/
            └── val.txt
```
Training:
```bash
  litgpt pretrain_mixed $model_name \
    --initial_checkpoint_dir "${checkpoint_dir}/step${step}" \
    --tokenizer_dir "${checkpoint_dir}/step${step}" \
    --data MixedDataset \
    --data.data_path $mixed_data_dir \
    --train.max_tokens 20_000_000 \
    --train.global_batch_size 128 \
    --train.max_seq_len $max_seq_len \
    --train.min_lr 1e-7 \
    --out_dir "out/${model_name}_mixtrained_from_${step}"

```